### PR TITLE
Removed deletion of CVS subdirectories from RPM tar.gz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,6 @@ genwqe-tools genwqe-libz:
 	@mkdir -p /tmp/$@-$(rpmversion)
 	@cp -ar .git /tmp/$@-$(rpmversion)/
 	@cp -ar * /tmp/$@-$(rpmversion)/
-	@find /tmp/$@-$(rpmversion)/ \
-		-depth -name 'CVS' -exec rm -rf '{}' \; -print
 	(cd /tmp && tar cfz $@-$(rpmversion).tgz $@-$(rpmversion))
 	@cp /tmp/$@-$(rpmversion).tgz ~/rpmbuild/SOURCES/
 	@cp spec/$@.spec ~/rpmbuild/SPECS/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ currently be aquired as an option to the latest IBM System p machines (see also 
         libcard.c           Low level API for GenWQE card
         libddcb.c           Functions on top of ddcb_card.c
         libzADC.map         Map file to build so files
-        libzHW.c            De/Compression supporting RFC1950, RFC1951 and RFC1952
+        libzHW.c            De/compression supporting RFC1950, RFC1951 and RFC1952
         software.c          Interface to call system libz
         wrapper.c           Wrapper for soft- and hardware-zlib
         wrapper.h
@@ -50,6 +50,11 @@ currently be aquired as an option to the latest IBM System p machines (see also 
     /licenses
         cla-corporate.txt
         cla-individual.txt
+
+    /spec
+        genwqe-libz.spec    Spec file for building the tools RPM
+        genwqe-tools.spec   Spec file for building the libz RPM
+
 
 On modern PowerPC server the accelerator card can use the new CAPI interface.
 Install the [libcxl](https://github.com/ibm-capi/libcxl.git) library into the toplevel ````genwqe-user```` directory and build the library via ````make```` before compiling the genwqe tools.


### PR DESCRIPTION
Since the RPM build is done now from this git repository, we do not
need to explicitly delete the CVS subdirectories anymore. We intentionally
keep the .git subdirectory in the RPM required to build the RPM to get
the correct version information.
