### PR TITLE
Fix problem with installations not having a zlib-dev package

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -52,8 +52,10 @@ PLATFORM = $(shell uname -i)
 
 CFLAGS = -W -Wall -Werror -Wwrite-strings -Wextra -Os -g \
 	-DGIT_VERSION=\"$(GIT_VERSION)\" \
-	-I../include -I../include/linux/uapi \
+	-I. -I/opt/genwqe/include -I../include -I../include/linux/uapi \
 	-Wmissing-prototypes # -Wstrict-prototypes -Warray-bounds
+
+LDFLAGS += -L/opt/genwqe/lib
 
 # Force 32-bit build
 #   This is needed to generate the code for special environments. We have

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -20,10 +20,8 @@ instdir ?= /opt/genwqe
 libversion = $(shell git describe --abbrev=4 --dirty --always --tags)
 zlibver=1.2.8
 
-CFLAGS += -fPIC -I. -I/opt/genwqe/include -fno-strict-aliasing \
+CFLAGS += -fPIC -fno-strict-aliasing \
 	-DCONFIG_ZLIB_PATH=\"/opt/genwqe/lib/libz.so\"
-
-LDFLAGS += -L/opt/genwqe/lib
 
 ### Accelerated libz implemenation (Accelerated Data Compression/ADC)
 libname=libzADC

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -30,9 +30,9 @@ genwqe_vpdconv_objs = genwqe_vpd_common.o
 
 genwqe_memcopy_libs = -lz
 genwqe_cksum_libs = -lz
-genwqe_gzip_libs = ../lib/libzADC.a -ldl
-genwqe_gunzip_libs = ../lib/libzADC.a -ldl
-zlib_mt_perf_libs = ../lib/libzADC.a -ldl
+genwqe_gzip_libs = ../lib/libzADC.a -ldl	# statically link our libz
+genwqe_gunzip_libs = ../lib/libzADC.a -ldl	# statically link our libz
+zlib_mt_perf_libs = ../lib/libzADC.a -ldl	# statically link our libz
 
 projs = genwqe_update genwqe_gzip genwqe_gunzip zlib_mt_perf genwqe_memcopy \
 	genwqe_echo genwqe_peek genwqe_poke genwqe_cksum \

--- a/tools/genwqe_gzip.c
+++ b/tools/genwqe_gzip.c
@@ -48,8 +48,8 @@
 #define __USE_GNU
 #include <sched.h>
 
-#include "zlib.h"		/* Our version of zlib */
-#include "zaddons.h"		/* zlib extensions */
+#include <zlib.h>
+#include <zaddons.h>
 
 #define SET_BINARY_MODE(file)
 


### PR DESCRIPTION
We have seen installations where there was no zlib-dev package containing
zlib.h to build the code. Our circumvention for this is to use a private
copy of zlib in /opt/genwqe/include|lib. Unfortunately the search path
to find those was only setup for the library and not for the tools.
This change should fix that. Unfortunately I was unable to remove my
zlib-dev on my development box due to important packages depending on it.
So someone needs to try out if this fix really works.
