### PR TITLE
Fix for CAPI Multithread

### DIFF
--- a/lib/ddcb_capi.c
+++ b/lib/ddcb_capi.c
@@ -720,6 +720,7 @@ static void *__ddcb_done_thread(void *card_data)
 			VERBOSE2("WARNING: %d sec timeout while waiting "
 				 "for interrupt! rc: %d --> %d\n",
 				 ctx->tout, rc, DDCB_ERR_IRQTIMEOUT);
+			__ddcb_done_post(ctx, DDCB_ERR_IRQTIMEOUT);
 			rt_trace_dump();
 			continue;
 		}


### PR DESCRIPTION
This fix provides new code for the CAPI ddcb handler for multiple threads. The DDCB Queue size is changed to 4 which will be good for almost any transfer to the Card. Waiting threads will get blocked if the queue is full.
I also added trace function's.
Some minor fixes are made in the Memory copy  test application tool.
