### PR TITLE
Fix for Capi AFU open and AFU Close

### DIFF
--- a/tools/genwqe_memcopy.c
+++ b/tools/genwqe_memcopy.c
@@ -805,14 +805,14 @@ int main(int argc, char *argv[])
 				ip.card_no, ip.card_type, err_code,
 				accel_strerror(pt->accel, err_code));
 			pt->err = EX_ERR_CARD;
-			break;
+			continue;
 		}
 		/* Alloc ibuf */
 		pt->err = __memcpy_alloc_ibuf(&ip, pt);
-		if (0 != pt->err) {
-			accel_close(pt->accel);
-			break;
-		}
+		//if (0 != pt->err) {
+			//accel_close(pt->accel);
+			//break;
+		//}
 	}
 	pt = &tdata[0];
 	for (thread = 0; thread < ip.threads; thread++, pt++) {

--- a/tools/zlib_mt_perf.sh
+++ b/tools/zlib_mt_perf.sh
@@ -138,6 +138,10 @@ print_hdr=""
 for t in 1 2 3 4 8 16 32 64 128 160 ; do
     zlib_mt_perf $verbose -i$bufsize -o$bufsize -D -f ${test_data} \
 	-c$count -t$t $print_hdr;
+	if [ $? -ne 0 ]; then
+            echo "failed with $t Threads"
+            exit 1
+        fi
     # sleep 1 ;
     print_hdr="-N";
 done


### PR DESCRIPTION
This fix does close the issue where the attach AFU thread and the close AFU thread is not the same.
