### PR TITLE
Support AFU Directed mode

### DIFF
--- a/include/libddcb.h
+++ b/include/libddcb.h
@@ -54,6 +54,10 @@ extern "C" {
 #define DDCB_MODE_ASYNC			0x0008 /* ... */
 #define DDCB_MODE_NONBLOCK		0x0010 /* non blocking, -EBUSY */
 #define DDCB_MODE_POLLING		0x0020 /* polling */
+#define DDCB_MODE_MASTER		0x08000000 /* Open Master Context, Slave is default, CAPI ony */
+#define DDCB_MODE_MASTER_F_CHECK	0x04000000 /* Master Context, FIR Check, CAPI ony */
+#define DDCB_MODE_MASTER_T_CHECK	0x02000000 /* Master Context, Time Check, CAPI ony */
+#define DDCB_MODE_MASTER_DT		0xF0000000 /* Master Context, Delay Time Mask, CAPI ony */
 
 #define DDCB_APPL_ID_IGNORE		0x0000000000000000 /* Ignore applid */
 #define DDCB_APPL_ID_MASK		0x00000000ffffffff /* Valid bits */
@@ -205,6 +209,7 @@ const char *accel_strerror(accel_t card, int card_rc); /* card errcode */
 
 void ddcb_hexdump(FILE *fp, const void *buff, unsigned int size);
 void ddcb_debug(int verbosity);
+void ddcb_debug_log(FILE *fd_out);
 
 /**
  * @brief Get accel_handle

--- a/lib/ddcb_capi.c
+++ b/lib/ddcb_capi.c
@@ -931,11 +931,8 @@ static int __ddcb_process_irqs(struct dev_ctx *ctx)
 
 		rc = select(ctx->afu_fd + 1, &set, NULL, NULL, &timeout);
 		if (0 == rc) {
-			VERBOSE0("WARNING: %d sec timeout while waiting "
-				 "for interrupt! rc: %d --> %d\n",
-				 ctx->tout, rc, DDCB_ERR_IRQTIMEOUT);
+			/* Timeout will Post error code only if context is active */
 			__ddcb_done_post(ctx, DDCB_ERR_IRQTIMEOUT);
-			//rtc_trace_dump();
 			continue;
 		}
 		if ((rc == -1) && (errno == EINTR)) {

--- a/lib/libddcb.c
+++ b/lib/libddcb.c
@@ -82,6 +82,7 @@ static unsigned int ddcb_trace = 0x0;
 
 static struct ddcb_accel_funcs *accel_list = NULL;
 int libddcb_verbose = 0;
+FILE *libddcb_fd_out;
 
 static inline uint64_t get_usec(void)
 {
@@ -186,6 +187,11 @@ void ddcb_hexdump(FILE *fp, const void *buff, unsigned int size)
 void ddcb_debug(int verbosity)
 {
 	libddcb_verbose = verbosity;
+}
+
+void ddcb_debug_log(FILE *fd_out)
+{
+	libddcb_fd_out  = fd_out;
 }
 
 accel_t accel_open(int card_no, unsigned int card_type,
@@ -514,6 +520,7 @@ static void _init(void)
 {
 	const char *ddcb_trace_env = getenv("DDCB_TRACE");
 
+	libddcb_fd_out = stderr;	/* Default fd out for messages */
 	if (ddcb_trace_env != NULL)
 		ddcb_trace = strtol(ddcb_trace_env, (char **)NULL, 0);
 }

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -36,7 +36,8 @@ zlib_mt_perf_libs = ../lib/libzADC.a -ldl	# statically link our libz
 
 projs = genwqe_update genwqe_gzip genwqe_gunzip zlib_mt_perf genwqe_memcopy \
 	genwqe_echo genwqe_peek genwqe_poke genwqe_cksum \
-	genwqe_vpdconv genwqe_vpdupdate csv2bin genwqe_loadtree genwqe_ffdc
+	genwqe_vpdconv genwqe_vpdupdate csv2bin genwqe_loadtree genwqe_ffdc \
+	genwqe_maint
 
 objs = force_cpu.o genwqe_vpd_common.o $(projs:=.o)
 

--- a/tools/genwqe_maint.c
+++ b/tools/genwqe_maint.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2015, International Business Machines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Genwqe Capi Card Master Maintenence tool.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <ctype.h>
+#include <signal.h>
+#include <stdbool.h>
+
+#include <libddcb.h>
+#include "genwqe_tools.h"
+
+static const char *version = GIT_VERSION;
+int	verbose_flag = 0;
+
+struct my_sig_data {
+	accel_t	card;
+	bool	verbose;
+	FILE	*fd_out;
+};
+
+/* Return true if card Software Release is OK */
+static bool check_app(accel_t card)
+{
+	uint64_t data;
+
+	/* Check Application Version for Version higher than 0403 */
+	/* Register 8 does have following layout for the 64 bits */
+	/* RRRRFFIINNNNNNNN */
+	/* RRRR     == 16 bit Software Release (0404) */
+	/* FF       ==  8 bit Software Fix Level on card (01) */
+	/* II       ==  8 bit Software Interface ID (03) */
+	/* NNNNNNNN == 32 Bit Function (475a4950) = (GZIP) */
+	data = accel_get_app_id(card);
+	data = data >> 32;
+	if (0x03 == (data & 0xff)) {
+		/* Check 16 bits Release */
+		data = data >> 16;
+		if (data > 0x0500)	/* CAPI directed mode starts at 0500 */
+			return true;
+	}
+	return false;
+}
+
+static FILE *fd_out;
+static bool deamon = false;
+static accel_t card;
+static pid_t	my_sid;
+
+static void sig_handler(int sig)
+{
+
+	fprintf(fd_out, "Sig Handler Signal: %d SID: %d\n", sig, my_sid);
+	if (card)
+		accel_close(card);
+	if (deamon) {
+		if (fd_out) {
+			fflush(fd_out);
+			fclose(fd_out);
+		}
+	}
+	exit(0);
+}
+
+static void help(char *prog)
+{
+	printf("Usage: %s [-CvhVd] [-f file] [-t runtime] [-i delay]\n"
+		"\t-C, --card <num>	Card to use (default 0)\n"
+		"\t-V, --version	Print Version number\n"
+		"\t-h, --help		This help message\n"
+		"\t-q, --quiet		No output at all\n"
+		"\t-v, --verbose	verbose mode, up to -vvv\n"
+		"\t-t, --runtime <num>	Run time in sec (default 1 sec) (forground)\n"
+		"\t-i, --interval <num>	Interval time in sec (default 1 sec)\n"
+		"\t-d, --deamon		Start in Deamon process (background)\n"
+		"\t-f, --log-file <file> Log File name when running in -d (deamon)\n",
+		prog);
+	return;
+}
+
+/**
+ * Get command line parameters and create the output file.
+ */
+int main(int argc, char *argv[])
+{
+	bool quiet = false;
+	int	card_no = 0;
+	int rc;
+	int ch;
+	int	err_code;
+	pid_t	pid;
+	char *log_file = NULL;
+	int delay = 1;		/* Default 10 sec delay */
+	int interval = 1;	/* Default 1 sec interval */
+	int mode = DDCB_MODE_WR |
+		DDCB_MODE_MASTER |
+		DDCB_MODE_MASTER_F_CHECK;	/* turn FIR Check on */
+
+	fd_out = stdout;
+	rc = EXIT_SUCCESS;
+	while (1) {
+		int option_index = 0;
+		static struct option long_options[] = {
+			{ "card",       required_argument, NULL, 'C' },
+			{ "version",    no_argument,       NULL, 'V' },
+			{ "quiet",      no_argument,       NULL, 'q' },
+			{ "help",       no_argument,       NULL, 'h' },
+			{ "verbose",    no_argument,       NULL, 'v' },
+			{ "runtime",    required_argument, NULL, 't' },
+			{ "interval",   required_argument, NULL, 'i' },
+			{ "deamon",     no_argument,       NULL, 'd' },
+			{ "log-file",   required_argument, NULL, 'f' },
+			{ 0,            no_argument,       NULL,  0  },
+		};
+		ch = getopt_long(argc, argv, "C:f:t:i:Vqhvd",
+			long_options, &option_index);
+		if (-1 == ch)
+			break;
+		switch (ch) {
+		case 'C':	/* --card */
+			card_no = strtol(optarg, (char **)NULL, 0);
+			break;
+		case 'V':	/* --version */
+			fprintf(fd_out, "%s\n", version);
+			exit(EXIT_SUCCESS);
+			break;
+		case 'q':	/* --quiet */
+			quiet = true;
+			break;
+		case 'h':	/* --help */
+			help(argv[0]);
+			exit(EXIT_SUCCESS);
+			break;
+		case 'v':	/* --verbose */
+			verbose_flag++;
+			break;
+		case 't':	/* --runtime */
+			delay = strtoul(optarg, NULL, 0);
+			break;
+		case 'i':	/* --interval */
+			interval = strtoul(optarg, NULL, 0);
+			mode |= (interval << 28) & DDCB_MODE_MASTER_DT;
+			break;
+		case 'd':	/* --deamon */
+			deamon = true;
+			break;
+		case 'f':	/* --log-file */
+			log_file = optarg;
+			break;
+		default:
+			help(argv[0]);
+			exit(EXIT_FAILURE);
+		}
+	}
+
+	if (deamon) {
+		if (NULL == log_file) {
+			printf("Please Provide log file name (-f) if running "
+				"in deamon mode !\n");
+			exit(1);
+		}
+	}
+	if (log_file) {
+		fd_out = fopen(log_file, "w+");
+		if (NULL == fd_out) {
+			printf("Can not create/append to file %s\n", log_file);
+			exit(1);
+		}
+	}
+	signal(SIGCHLD,SIG_IGN);	/* ignore child */
+	signal(SIGTSTP,SIG_IGN);	/* ignore tty signals */
+	signal(SIGTTOU,SIG_IGN);
+	signal(SIGTTIN,SIG_IGN);
+	signal(SIGHUP,sig_handler);	/* catch -1 hangup signal */
+	signal(SIGINT, sig_handler);	/* Catch -2 */
+	signal(SIGKILL,sig_handler);	/* catch -9 kill signal */
+	signal(SIGTERM,sig_handler);	/* catch -15 kill signal */
+
+	if (deamon) {
+		pid = fork();
+		if (pid < 0) {
+			printf("Fork() failed\n");
+			exit(1);
+		}
+		if (pid > 0) {
+			printf("Child Pid is %d Parent exit here\n", pid);
+			exit(0);
+		}
+		if (chdir("/")) {
+			printf("Can not chdir to / !!!\n");
+			exit(1);
+		}
+		umask(0);
+		//set new session
+		my_sid = setsid();
+		printf("Child sid: %d from pid: %d\n", my_sid, pid);
+		if(my_sid < 0)
+			exit(1);
+		close(STDIN_FILENO);
+		close(STDOUT_FILENO);
+		close(STDERR_FILENO);
+	}
+	ddcb_debug(verbose_flag);
+	if (!quiet && verbose_flag)
+		fprintf(fd_out, "Open CAPI Card: %d\n", card_no);
+	card = accel_open(card_no, DDCB_TYPE_CAPI, mode,
+			  &err_code, 0, DDCB_APPL_ID_IGNORE);
+	if (NULL == card) {
+		fprintf(fd_out, "Err: failed to open Master Context for CAPI Card: %u\n",
+                        card_no),
+		fprintf(fd_out, "\tcheck Permissions in /dev/cxl/* or kernel log.\n");
+                exit(EXIT_FAILURE);
+	}
+
+	if (false == check_app(card)) {
+		fprintf(fd_out, "Err: Wrong Card Appl ID. Need to have > 0500\n");
+		accel_close(card);
+                exit(EXIT_FAILURE);
+	}
+	if (deamon) {
+		while(1) {
+			fprintf(fd_out, "Deamon Pid %d still running, Log file: %s\n",
+				my_sid, log_file);
+			sleep(60);	/* Nothing to da */
+		}
+	} else {
+		sleep(delay);
+	}
+	accel_close(card);
+	if (!quiet && verbose_flag)
+		fprintf(fd_out, "Close Capi Card: %d\n", card_no);
+	exit(rc);
+}

--- a/tools/genwqe_memcopy.c
+++ b/tools/genwqe_memcopy.c
@@ -783,7 +783,8 @@ int main(int argc, char *argv[])
 	}
 
 	switch_cpu(ip.cpu, verbose_flag);
-	ddcb_debug(verbose_flag);
+	if (verbose_flag > 1)
+	ddcb_debug(verbose_flag - 1);
 
 	/* Allocate Thread data */
 	tdata = (struct memcpy_thread_data*)

--- a/tools/genwqe_peek.c
+++ b/tools/genwqe_peek.c
@@ -83,6 +83,7 @@ int main(int argc, char *argv[])
 	int quiet = 0;
 	unsigned long i, count = 1;
 	unsigned long interval = 0;
+	int mode = DDCB_MODE_WR;
 
 	while (1) {
 		int option_index = 0;
@@ -187,8 +188,12 @@ int main(int argc, char *argv[])
 	}
 
 	switch_cpu(cpu, verbose_flag);
+	ddcb_debug(verbose_flag);
 
-	card = accel_open(card_no, card_type, DDCB_MODE_RD, &err_code,
+	/* CAPI need's master flag for Poke */
+        if (DDCB_TYPE_CAPI == card_type)
+                mode |= DDCB_MODE_MASTER;
+	card = accel_open(card_no, card_type, mode, &err_code,
 			  0, DDCB_APPL_ID_IGNORE);
 	if (card == NULL) {
 		fprintf(stderr, "err: failed to open card %u type %u "
@@ -196,7 +201,6 @@ int main(int argc, char *argv[])
 			accel_strerror(card, err_code));
 		exit(EXIT_FAILURE);
 	}
-	ddcb_debug(verbose_flag);
 
 	for (i = 0; i < count; i++) {
 		switch (width) {

--- a/tools/genwqe_poke.c
+++ b/tools/genwqe_poke.c
@@ -85,6 +85,7 @@ int main(int argc, char *argv[])
 	int quiet = 0;
 	unsigned long i, count = 1;
 	unsigned long interval = 0;
+	int mode = DDCB_MODE_WR;	/* Default open mode for CAPI and GENWQE Card's */
 	int xerrno;
 
 	while (1) {
@@ -177,8 +178,13 @@ int main(int argc, char *argv[])
 	val  = strtoull(argv[optind++], NULL, 0);
 	rbval = ~val;
 	switch_cpu(cpu, verbose_flag);
+	ddcb_debug(verbose_flag);
 
-	card = accel_open(card_no, card_type, DDCB_MODE_WR, &err_code,
+	/* CAPI need's master flag for Poke */
+	if (DDCB_TYPE_CAPI == card_type)
+		mode |= DDCB_MODE_MASTER;
+
+	card = accel_open(card_no, card_type, mode, &err_code,
 			  0, DDCB_APPL_ID_IGNORE);
 	if (card == NULL) {
 		fprintf(stderr, "err: failed to open card %u type %u "
@@ -186,7 +192,6 @@ int main(int argc, char *argv[])
 			accel_strerror(card, err_code));
 		exit(EXIT_FAILURE);
 	}
-	ddcb_debug(verbose_flag);
 
 	for (i = 0; i < count; i++) {
 		switch (width) {


### PR DESCRIPTION
This is the first patch where we support "AFU directed mode".
You need to install FPGA code 5.0.0 or later after this patch. Use the "capi-flash-script.sh"
to upgrade your FPGA card.
You will have new devices (/dev/cxl/afu0.0s and /dev/cxl/afu0.0.m) after reboot.
Make sure to have access rights to you'r devices (e.g. udev rules).
Try "genwqe_echo -A CAPI -vv" to check if directed mode works.
