### PR TITLE
Adding statistic printout to libcard

### DIFF
--- a/include/libcard.h
+++ b/include/libcard.h
@@ -387,6 +387,8 @@ void card_overwrite_slu_id(card_handle_t card, uint64_t slu_id);
 void card_overwrite_app_id(card_handle_t card, uint64_t app_id);
 uint64_t card_get_app_id(card_handle_t card);
 
+int genwqe_dump_statistics(FILE *fp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/ddcb_card.c
+++ b/lib/ddcb_card.c
@@ -146,6 +146,11 @@ static int card_free(void *card_data, void *ptr, size_t size)
 	return genwqe_card_free(card_data, ptr, size);
 }
 
+static int _card_dump_statistics(FILE *fp)
+{
+	return genwqe_dump_statistics(fp);
+}
+
 static struct ddcb_accel_funcs accel_funcs = {
 	.card_type = DDCB_TYPE_GENWQE,
 	.card_name = "GENWQE",
@@ -168,6 +173,7 @@ static struct ddcb_accel_funcs accel_funcs = {
 	.card_free = card_free,
 
 	/* statistics */
+	.dump_statistics = _card_dump_statistics,
 	.num_open = 0,
 	.num_close = 0,
 	.num_execute = 0,


### PR DESCRIPTION
I wanted to know how many time libcard invoked recovery for failing
DDCBs. I used the chance to add statistic dump functionality for libcard
too. It already existed for our capi version. Output looks like this:

libddcb statistics for GENWQE
  open    ;     1 ;      299 usec
  execute ;  4963 ;  1282295 usec
  close   ;     1 ;       54 usec
GenWQE card statistics
  Completed DDCBs: 4963     // executed DDCBs in general
  Retried DDCBs:   92       // how many DDCBs needed to be repeated

Feature needs to be enabled by setting DDCB_TRACE=0x1 env variable.
