### PR TITLE
Adding option to statically link a z_ prefixed version of zlib

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -42,6 +42,7 @@ MAKEFLAGS	+= --silent
 MAKE		+= -s
 CC		= printf "\t[CC]\t%s\n" `basename "$@"`; $(CROSS)gcc
 AS		= printf "\t[AS]\t%s\n" `basename "$@"`; $(CROSS)as
+AR		= printf "\t[AR]\t%s\n" `basename "$@"`; $(CROSS)ar
 LD		= printf "\t[LD]\t%s\n" `basename "$@"`; $(CROSS)ld
 OBJCOPY		= printf "\t[OBJCOPY]\t%s\n" `basename "$@"`; $(CROSS)objcopy
 else
@@ -107,4 +108,16 @@ ifneq ($(CONFIG_LIBCXL_PATH),)          # Use libcxl
 CFLAGS += -I$(CONFIG_LIBCXL_PATH) -I$(CONFIG_LIBCXL_PATH)/include
 LDFLAGS += -L$(CONFIG_LIBCXL_PATH)
 libcxl_a = $(CONFIG_LIBCXL_PATH)/libcxl.a
+endif
+
+# z_ prefixed version of libz, intended to be linked statically with
+# our libz version to provide the software zlib functionality.
+#
+CONFIG_DLOPEN_MECHANISM ?= 1
+
+ifeq ($(CONFIG_DLOPEN_MECHANISM),1)
+CFLAGS += -DCONFIG_DLOPEN_MECHANISM
+else
+CONFIG_LIBZ_PATH=../zlib-1.2.8
+libz_a=libz_prefixed.o
 endif

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -112,7 +112,7 @@ $(libname2)-$(libversion).so: __$(libname2).o
 	$(CC) $(LDFLAGS) -shared -Wl,-soname,$@ -o $@ $^
 
 ### libzADC
-__$(libname).o: $(objs)
+__$(libname).o: $(objs) $(libz_a)
 	$(LD) $(XLDFLAGS) -r -o $@ $^
 
 $(libname).a: __$(libname).o
@@ -124,6 +124,38 @@ $(libname).so: $(libname)-$(libversion).so
 $(libname)-$(libversion).so: __$(libname).o
 	$(CC) $(LDFLAGS) -shared -Wl,-soname,$@ \
 		 -Wl,--version-script=libzADC.map -o $@ $^
+
+# Produce z_ prefixed verson of software zlib. We need this when we
+# want to include libz statially instead of using dlopen/dlsym to use
+# it.
+#
+# Special version of libz.a which has z_ prefixed function
+# names. Required for software zlib fallback in case of small buffers
+# and accelerator unavailability.
+#
+libz_prefixed.o:
+
+zlib_objs = $(CONFIG_LIBZ_PATH)/adler32.lo  \
+	    $(CONFIG_LIBZ_PATH)/infback.lo  \
+	    $(CONFIG_LIBZ_PATH)/compress.lo \
+	    $(CONFIG_LIBZ_PATH)/gzclose.lo  \
+	    $(CONFIG_LIBZ_PATH)/inffast.lo  \
+	    $(CONFIG_LIBZ_PATH)/trees.lo    \
+	    $(CONFIG_LIBZ_PATH)/crc32.lo    \
+	    $(CONFIG_LIBZ_PATH)/gzlib.lo    \
+	    $(CONFIG_LIBZ_PATH)/inflate.lo  \
+	    $(CONFIG_LIBZ_PATH)/uncompr.lo  \
+	    $(CONFIG_LIBZ_PATH)/deflate.lo  \
+	    $(CONFIG_LIBZ_PATH)/gzread.lo   \
+	    $(CONFIG_LIBZ_PATH)/inftrees.lo \
+	    $(CONFIG_LIBZ_PATH)/zutil.lo    \
+	    $(CONFIG_LIBZ_PATH)/gzwrite.lo
+
+libz_prefixed.o: libz.o
+	$(OBJCOPY) --prefix-symbols=z_ $< $@
+
+libz.o: $(CONFIG_LIBZ_PATH)/libz.so
+	$(LD) $(XLDFLAGS) -r -o $@ $(zlib_objs)
 
 install: all install_zlib
 	mkdir -p $(instdir)/lib


### PR DESCRIPTION
In some cases the accelerated zlib should be completely standalone and have
the same external dependencies like software zlib. Users can select a
makefile option to either use sw zlib via dlopen/dlsym or by building
a private version and linking against that.
