### PR TITLE
CGzip: Fix master context for peek and poke

### DIFF
--- a/lib/ddcb_capi.c
+++ b/lib/ddcb_capi.c
@@ -692,6 +692,7 @@ static void *card_open(int card_no, unsigned int mode, int *card_rc,
 	 */
 	if (ttx->card_no != ACCEL_REDUNDANT) {
 		ttx->ctx = &my_ctx[card_no];  /* select card context */
+		ttx->ctx->mode = mode;
 		rc = __client_inc(ttx->ctx);
 		if (rc != DDCB_OK) {
 			free(ttx);
@@ -700,10 +701,11 @@ static void *card_open(int card_no, unsigned int mode, int *card_rc,
 	} else {
 		/* open all possible cards */
 		for (i = 0; i < NUM_CARDS; i++) {
+			my_ctx[ttx->card_next].mode = mode;
 			rc = __client_inc(&my_ctx[ttx->card_next]);
-			if (rc == DDCB_OK)  /* remember last one which is ok */
+			if (rc == DDCB_OK) { /* remember last which is ok */
 				ttx->ctx = &my_ctx[ttx->card_next];
-
+			}
 			ttx->card_next = (ttx->card_next + 1) %	NUM_CARDS;
 		}
 	}

--- a/tools/genwqe_peek.c
+++ b/tools/genwqe_peek.c
@@ -191,8 +191,9 @@ int main(int argc, char *argv[])
 	ddcb_debug(verbose_flag);
 
 	/* CAPI need's master flag for Poke */
-        if (DDCB_TYPE_CAPI == card_type)
-                mode |= DDCB_MODE_MASTER;
+	if (DDCB_TYPE_CAPI == card_type)
+		mode |= DDCB_MODE_MASTER;
+
 	card = accel_open(card_no, card_type, mode, &err_code,
 			  0, DDCB_APPL_ID_IGNORE);
 	if (card == NULL) {

--- a/tools/genwqe_poke.c
+++ b/tools/genwqe_poke.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
 	int quiet = 0;
 	unsigned long i, count = 1;
 	unsigned long interval = 0;
-	int mode = DDCB_MODE_WR;	/* Default open mode for CAPI and GENWQE Card's */
+	int mode = DDCB_MODE_WR; /* Default mode for CAPI and GENWQE Card's */
 	int xerrno;
 
 	while (1) {


### PR DESCRIPTION
We opened the slave context even if we wanted to have the master context.
Fixed passing mode setting to lowlevel code to fix this issue.
