### PR TITLE
Modify to use ssh instead of https to get libcxl. 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ext/libcxl"]
 	path = ext/libcxl
-	url = https://github.com/ibm-capi/libcxl
+	url = ssh://git@github.com/ibm-capi/libcxl


### PR DESCRIPTION
Modify to use ssh instead of https to get libcxl. make sure you have 
permission in github to download via ssh by adding your ssh Key
into https://github.com/settings/ssh. We prefere SSH since it can
be used to tunnel down to our test  machines.
to clone the complete repository use:
"git clone --recursive ssh://git@github.com/ibm-genwqe/genwqe-user"
