### PR TITLE
Fixup rpm build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,22 +21,38 @@
 V ?= 2
 
 ifeq ($(V),0)
-	Q		:= @
-	MAKEFLAGS	+= --silent
-	MAKE		+= -s
+Q		:= @
+MAKEFLAGS	+= --silent
+MAKE		+= -s
 endif
 
 ifeq ($(V),1)
-	MAKEFLAGS	+= --silent
-	MAKE		+= -s
+MAKEFLAGS	+= --silent
+MAKE		+= -s
 endif
 
+HAS_GIT = $(shell git --help > /dev/null 2>&1 && echo y || echo n)
+
+ifeq (${HAS_GIT},y)
+VERSION ?= $(shell git describe --abbrev=4 --dirty --always --tags)
+RPMVERSION ?= $(shell git describe --abbrev=0 --tags)
+else
+VERSION=4.0.11
+RPMVERSION=$(VERSION)
+endif
+
+PLATFORM ?= $(shell uname -i)
+
 distro = $(shell lsb_release -d | cut -f2)
-subdirs += lib tools init
+subdirs += lib tools
+ifeq ($(PLATFORM),ppc64le)
+subdirs += init
+endif
 targets += $(subdirs)
 
 UDEV_RULES_D ?= /etc/udev/rules.d
 MODPROBE_D ?= /etc/modprobe.d
+
 
 all: $(targets)
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,11 @@ MAKEFLAGS	+= --silent
 MAKE		+= -s
 endif
 
-HAS_GIT = $(shell git --help > /dev/null 2>&1 && echo y || echo n)
+#
+# If we can use git to get a version, we use that. If not, we have
+# no repository and set a static version number.
+#
+HAS_GIT = $(shell git describe > /dev/null 2>&1 && echo y || echo n)
 
 ifeq (${HAS_GIT},y)
 VERSION ?= $(shell git describe --abbrev=4 --dirty --always --tags)

--- a/config.mk
+++ b/config.mk
@@ -31,9 +31,6 @@ STRIP		= $(CROSS)strip
 NM		= $(CROSS)nm
 HELP2MAN	= help2man
 
-VERSION=4.0.11
-RPMVERSION=$(VERSION)
-
 ifeq ($(V),0)
 Q		:= @
 MAKEFLAGS	+= --silent
@@ -52,7 +49,7 @@ else
 CLEAN		= echo -n
 endif
 
-PLATFORM = $(shell uname -i)
+PLATFORM ?= $(shell uname -i)
 
 CFLAGS = -W -Wall -Werror -Wwrite-strings -Wextra -Os -g \
 	-DGIT_VERSION=\"$(VERSION)\" \

--- a/init/Makefile
+++ b/init/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015, International Business Machines
+# Copyright 2016, International Business Machines
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,8 @@ all:
 clean:
 
 install:
-	install -D -m 644  genwqe_maint.service $(SYSTEMD_UNIT_DIR)/genwqe_maint.service
+	install -D -m 644 genwqe_maint.service \
+		$(SYSTEMD_UNIT_DIR)/genwqe_maint.service
 
 uninstall:
 	-rm $(SYSTEMD_UNIT_DIR)/genwqe_maint.service

--- a/init/Makefile
+++ b/init/Makefile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-SYSTEMD_UNIT_DIR?=$(DESTDIR)/usr/lib/systemd/system
+SYSTEMD_UNIT_DIR?=$(DESTDIR)/lib/systemd/system
 
 all:
 clean:

--- a/spec/genwqe.spec
+++ b/spec/genwqe.spec
@@ -110,9 +110,10 @@ GenWQE adapter VPD tools
 
 %ifarch ppc64le
 %{_bindir}/genwqe_maint
+%{_prefix}/lib/systemd/system/genwqe_maint.service
 %{_bindir}/genwqe_loadtree
-%{_mandir}/genwqe_maint.1.gz
-%{_mandir}/genwqe_loadtree.1.gz
+%{_mandir}/man1/genwqe_maint.1.gz
+%{_mandir}/man1/genwqe_loadtree.1.gz
 %endif
 
 

--- a/spec/genwqe.spec
+++ b/spec/genwqe.spec
@@ -78,15 +78,43 @@ GenWQE adapter VPD tools
 %files -n genwqe-tools
 %doc LICENSE
 %defattr(0755,root,root)
-%{_bindir}/genwqe_*
-%{_bindir}/zlib_mt_perf
-%{_bindir}/genwqe_mt_perf
-%{_bindir}/genwqe_test_gz
 %{_bindir}/genwqe/gunzip
 %{_bindir}/genwqe/gzip
+%{_bindir}/genwqe_echo
+%{_bindir}/genwqe_ffdc
+%{_bindir}/genwqe_gunzip
+%{_bindir}/genwqe_gzip
+%{_bindir}/genwqe_cksum
+%{_bindir}/genwqe_memcopy
+%{_bindir}/genwqe_mt_perf
+%{_bindir}/genwqe_peek
+%{_bindir}/genwqe_poke
+%{_bindir}/genwqe_test_gz
+%{_bindir}/genwqe_update
+%{_bindir}/zlib_mt_perf
 
-%{_mandir}/man1/genwqe_*.gz
+%{_mandir}/man1/genwqe_echo.1.gz
+%{_mandir}/man1/genwqe_ffdc.1.gz
+%{_mandir}/man1/genwqe_gunzip.1.gz
+%{_mandir}/man1/genwqe_gzip.1.gz
+%{_mandir}/man1/genwqe_cksum.1.gz
+%{_mandir}/man1/genwqe_memcopy.1.gz
+%{_mandir}/man1/genwqe_peek.1.gz
+%{_mandir}/man1/genwqe_poke.1.gz
+%{_mandir}/man1/genwqe_update.1.gz
 %{_mandir}/man1/zlib_mt_perf.1.gz
+
+# Not yet working with help2man
+#%{_mandir}/man1/genwqe_mt_perf.1.gz
+#%{_mandir}/man1/genwqe_test_gz.1.gz
+
+%ifarch ppc64le
+%{_bindir}/genwqe_maint
+%{_bindir}/genwqe_loadtree
+%{_mandir}/genwqe_maint.1.gz
+%{_mandir}/genwqe_loadtree.1.gz
+%endif
+
 
 %files -n genwqe-zlib
 %doc LICENSE
@@ -100,6 +128,7 @@ GenWQE adapter VPD tools
 %{_bindir}/genwqe_csv2vpd
 %{_bindir}/genwqe_vpdconv
 %{_bindir}/genwqe_vpdupdate
+
 %{_mandir}/man1/genwqe_csv2vpd.1.gz
 %{_mandir}/man1/genwqe_vpdconv.1.gz
 %{_mandir}/man1/genwqe_vpdupdate.1.gz

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -36,12 +36,12 @@ zlib_mt_perf_libs = ../lib/libzADC.a -ldl	# statically link our libz
 
 projs = genwqe_update genwqe_gzip genwqe_gunzip zlib_mt_perf genwqe_memcopy \
 	genwqe_echo genwqe_peek genwqe_poke genwqe_cksum \
-	genwqe_vpdconv genwqe_vpdupdate genwqe_csv2vpd genwqe_loadtree \
+	genwqe_vpdconv genwqe_vpdupdate genwqe_csv2vpd \
 	genwqe_ffdc
 
 # Do this only on platforms where we have a libcxl available e.g. System p
 ifneq ($(CONFIG_LIBCXL_PATH),)
-projs += genwqe_maint
+projs += genwqe_maint genwqe_loadtree
 endif
 
 all: $(projs)
@@ -53,7 +53,7 @@ $(projs): $(libs)
 
 objs = force_cpu.o genwqe_vpd_common.o $(projs:=.o)
 
-manpages = $(projs:=.1)
+manpages = $(projs:=.1.gz)
 
 manpages: all $(manpages)
 
@@ -74,6 +74,9 @@ genwqe_gunzip.o: genwqe_gzip.c
 
 %.1: %
 	$(HELP2MAN) -N --output=$@ --name "IBM Hardware Accelerator Tool." ./$<
+
+%.1.gz: %.1
+	gzip --best -c $< > $@
 
 #
 # Tools for card maintenance

--- a/tools/genwqe_test_gz
+++ b/tools/genwqe_test_gz
@@ -30,7 +30,7 @@ export ZLIB_ACCELERATOR=GENWQE
 export ZLIB_CARD=-1
 
 # Directories used
-INSTALL_DIR="/opt/genwqe"                    # Tool RPM install directory
+INSTALL_DIR="/usr"                           # Tool RPM install directory
 TOOLS_DIR="${INSTALL_DIR}/bin/genwqe"        # gzip, gunzip install directory
 TMP_DIR="/tmp"                               # Temporary directory to use
 DATA_DIR="${TMP_DIR}/$$_testdata"            # directory for testdata


### PR DESCRIPTION
Gabriel, please have a look at these patches. We constantly have problems to get the build with and without libcxl right. Since genwqe_maint and the treebuild code are only for CAPI, therefore libcxl dependent and for s390/x86_64 we do not have that. Furthermore I sometimes break simulation when touching this ...
That is why it is important that the "make rpmbuild" rule really works, to enable check checking (VERSION, RPMVERSION etc. ...).
