### PR TITLE
Fix libz so 1 problem

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -115,7 +115,7 @@ endif
 # spec file during RPM build.
 #
 CONFIG_DLOPEN_MECHANISM ?= 1
-CONFIG_ZLIB_PATH ?= /opt/genwqe/lib/libz.so
+CONFIG_ZLIB_PATH ?= /opt/genwqe/lib/libz.so.1
 
 ifeq ($(CONFIG_DLOPEN_MECHANISM),1)
 CFLAGS += -DCONFIG_DLOPEN_MECHANISM -DCONFIG_ZLIB_PATH=\"$(CONFIG_ZLIB_PATH)\"

--- a/lib/software.c
+++ b/lib/software.c
@@ -449,9 +449,9 @@ void zedc_sw_init(void)
 		goto load_syms;
 
 	/* try loading system zlib.so */
-	sw_trace("Try loading system software zlib \"libz.so\"\n");
+	sw_trace("Try loading system software zlib \"libz.so.1\"\n");
 	dlerror();
-	handle = dlopen("libz.so", RTLD_LAZY);
+	handle = dlopen("libz.so.1", RTLD_LAZY);
 	if (handle == NULL) {
 		pr_err("  %s\n", dlerror());
 		return;

--- a/lib/software.c
+++ b/lib/software.c
@@ -529,8 +529,10 @@ load_syms:
 
 void zedc_sw_done(void)
 {
-	sw_trace("Closing software zlib\n");
-	dlclose(handle);
+	if (handle != NULL) {
+		sw_trace("Closing software zlib\n");
+		dlclose(handle);
+	}
 }
 
 #else

--- a/spec/genwqe.spec
+++ b/spec/genwqe.spec
@@ -56,7 +56,7 @@ GenWQE adapter VPD tools
 
 %build
 %{__make} %{?_smp_mflags} tools lib VERSION=%{version} \
-	CONFIG_ZLIB_PATH=%{_libdir}/libz.so
+	CONFIG_ZLIB_PATH=%{_libdir}/libz.so.1
 
 %install
 %{__make} %{?_smp_mflags} install DESTDIR=%{buildroot}/%{_prefix} VERSION=%{version}


### PR DESCRIPTION
Gabriel and I discovered that the RHEL zlib package does not provide libz.so. That is provided by the zlib-devel package. We like to keep the dependencies as small as possible and therefore use libz.so.1 instead of libz.so and need only the software zlib package installed and not its development version.

At the some time fixing a segfault when software zlib load failed.
