### PR TITLE
Adding zlib logfile support to remove the stderr dependency

### DIFF
--- a/lib/hardware.c
+++ b/lib/hardware.c
@@ -1127,11 +1127,11 @@ static inline int __check_stream_end(z_streamp strm)
 
 	hw_trace("Accumulated input data:\n");
 	if (zlib_hw_trace_enabled())
-		ddcb_hexdump(stderr, e.d, e.avail_in);
+		ddcb_hexdump(zlib_log, e.d, e.avail_in);
 
 	/* Now let us have a look what we have here */
 	while (1) {
-		/* fprintf(stderr, "STATE: %s\n", state_str[e.state]); */
+		/* fprintf(zlib_log, "STATE: %s\n", state_str[e.state]); */
 		switch (e.state) {
 		case READ_HDR:
 			rc = get_bits(&e, 3, &d);
@@ -1298,13 +1298,13 @@ int h_inflate(z_streamp strm, int flush)
 			rc = Z_OK;
 #ifdef CONFIG_CIRCUMVENTION_FOR_Z_STREAM_END /* EXPERIMENTAL for MongoDB PoC */
 			/*
-			 * fprintf(stderr, "SCRATCH\n");
-			 * ddcb_hexdump(stderr, h->wsp->tree,
+			 * fprintf(zlib_log, "SCRATCH\n");
+			 * ddcb_hexdump(zlib_log, h->wsp->tree,
 			 *	     __in_hdr_scratch_len(h));
-			 * fprintf(stderr, "NEXT_IN\n");
-			 * ddcb_hexdump(stderr, strm->next_in,
+			 * fprintf(zlib_log, "NEXT_IN\n");
+			 * ddcb_hexdump(zlib_log, strm->next_in,
 			 *	     MIN(strm->avail_in, (unsigned int)0x20));
-			 * fprintf(stderr,
+			 * fprintf(zlib_log,
 			 *	"  in_hdr_scratch_len = %d\n"
 			 *	"  proc_bits = %d\n",
 			 *	__in_hdr_scratch_len(h), h->proc_bits);

--- a/lib/wrapper.h
+++ b/lib/wrapper.h
@@ -28,6 +28,7 @@
  */
 
 #include <stdint.h>
+#include <stdio.h>
 #include <pthread.h>
 #include <zaddons.h>
 
@@ -39,6 +40,8 @@
 #  define __unused __attribute__((unused))
 #endif
 
+extern FILE *zlib_log;
+
 #define zlib_trace_enabled()       (zlib_trace & 0x1)
 #define zlib_hw_trace_enabled()    (zlib_trace & 0x2)
 #define zlib_sw_trace_enabled()    (zlib_trace & 0x4)
@@ -46,37 +49,37 @@
 
 /* Use in case of an error */
 #define pr_err(fmt, ...) do {						\
-		fprintf(stderr, "%s:%u: Error: " fmt,			\
+		fprintf(zlib_log, "%s:%u: Error: " fmt,		\
 			__FILE__, __LINE__, ## __VA_ARGS__);		\
 	} while (0)
 
 /* Use in case of an warning */
 #define pr_warn(fmt, ...) do {						\
-		fprintf(stderr, "%s:%u: Warning: " fmt,			\
+		fprintf(zlib_log, "%s:%u: Warning: " fmt,		\
 			__FILE__, __LINE__, ## __VA_ARGS__);		\
 	} while (0)
 
 /* Informational printouts */
 #define pr_info(fmt, ...) do {						\
-		fprintf(stderr, "Info: " fmt, ## __VA_ARGS__);		\
+		fprintf(zlib_log, "Info: " fmt, ## __VA_ARGS__);	\
 	} while (0)
 
 /* Trace zlib wrapper code */
 #define pr_trace(fmt, ...) do {						\
 		if (zlib_trace_enabled())				\
-			fprintf(stderr, "### " fmt, ## __VA_ARGS__);	\
+			fprintf(zlib_log, "### " fmt, ## __VA_ARGS__); \
 	} while (0)
 
 /* Trace zlib hardware implementation */
 #define hw_trace(fmt, ...) do {						\
 		if (zlib_hw_trace_enabled())				\
-			fprintf(stderr, "hhh " fmt, ## __VA_ARGS__);	\
+			fprintf(zlib_log, "hhh " fmt, ## __VA_ARGS__); \
 	} while (0)
 
 /* Trace zlib software implementation */
 #define sw_trace(fmt, ...) do {						\
 		if (zlib_sw_trace_enabled())				\
-			fprintf(stderr, "sss " fmt, ## __VA_ARGS__);	\
+			fprintf(zlib_log, "sss " fmt, ## __VA_ARGS__); \
 	} while (0)
 
 #define Z_UNSUPPORTED (-7)


### PR DESCRIPTION
We saw that some applications e.g. httpd might close stderr once they
are up and running. To get our statistical data and logs, we offer
here the possiblity to set e.g. ZLIB_LOGIFILE=/tmp/zlib.log to get
our data.
