### PR TITLE
Build system: Build cxl in one step.

### DIFF
--- a/spec/genwqe.spec
+++ b/spec/genwqe.spec
@@ -64,9 +64,6 @@ developing applications that use %{name}.
 %endif
 
 %build
-%ifarch ppc64le
-%{__make} -C ext/libcxl CFLAGS="-I../include"
-%endif
 
 %{__make} %{?_smp_mflags} tools lib VERSION=%{version} \
        CONFIG_ZLIB_PATH=%{_libdir}/libz.so.1 %{?libcxl}


### PR DESCRIPTION
to avoid missing compiler flags, build everything at once.

Signed-off-by: Gabriel Krisman Bertazi krisman@linux.vnet.ibm.com
