### PR TITLE
Issue 111

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -72,7 +72,7 @@ PLATFORM ?= $(shell uname -i)
 CFLAGS ?= -W -Wall -Werror -Wwrite-strings -Wextra -O2 -g \
 	-Wmissing-prototypes # -Wstrict-prototypes -Warray-bounds
 CFLAGS += -DGIT_VERSION=\"$(VERSION)\" \
-	-I. -I../include -I../include/linux/uapi
+	-I. -I../include -I../include/linux/uapi -D_GNU_SOURCE=1
 
 # Force 32-bit build
 #   This is needed to generate the code for special environments. We have

--- a/lib/ddcb_capi.c
+++ b/lib/ddcb_capi.c
@@ -882,7 +882,7 @@ static int ddcb_execute(void *card_data, struct ddcb_cmd *cmd)
 
 	rc = __ddcb_execute_multi(card_data, cmd);
 	if (DDCB_OK != rc)
-		errno = EINTR;
+		errno = EBADF;	/* Return Invalid exchange */
 
 	return rc;
 }

--- a/lib/ddcb_capi.c
+++ b/lib/ddcb_capi.c
@@ -33,7 +33,6 @@
 #include <time.h>
 #include <limits.h>
 #include <fcntl.h>
-#define _GNU_SOURCE
 #include <signal.h>
 #include <pthread.h>
 #include <semaphore.h>

--- a/lib/ddcb_capi.c
+++ b/lib/ddcb_capi.c
@@ -46,6 +46,7 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <dirent.h>
+#include <unistd.h>
 
 #include <libddcb.h>
 #include <ddcb.h>
@@ -607,7 +608,7 @@ static int card_dev_open(struct dev_ctx *ctx)
 		return DDCB_ERR_ENOMEM;
 	}
 
-	sem_wait(&ctx->open_done_sem);
+	TEMP_FAILURE_RETRY(sem_wait(&ctx->open_done_sem));
 	rc = ctx->afu_rc;	/* Get RC */
 	if (DDCB_OK != rc) {
 		/* The thread was not able to open or init tha AFU */
@@ -822,7 +823,7 @@ static int __ddcb_execute_multi(void *card_data, struct ddcb_cmd *cmd)
 
 	while (my_cmd) {
 		sem_getvalue(&ctx->free_sem, &val);
-		sem_wait(&ctx->free_sem);
+		TEMP_FAILURE_RETRY(sem_wait(&ctx->free_sem));
 
 		pthread_mutex_lock(&ctx->lock);
 
@@ -856,7 +857,7 @@ static int __ddcb_execute_multi(void *card_data, struct ddcb_cmd *cmd)
 
 	/* Block Caller */
 	VERBOSE2("[%s] Wait ttx: %p\n", __func__, ttx);
-	sem_wait(&ttx->wait_sem);
+	TEMP_FAILURE_RETRY(sem_wait(&ttx->wait_sem));
 	rt_trace(0x00af, ttx->seqnum, idx, ttx);
 	VERBOSE2("[%s] return ttx: %p\n", __func__, ttx);
 	return ttx->compl_code;	/* Give Completion code back to caller */

--- a/lib/ddcb_card.c
+++ b/lib/ddcb_card.c
@@ -30,7 +30,6 @@
 #include <time.h>
 #include <limits.h>
 #include <fcntl.h>
-#define _GNU_SOURCE
 #include <signal.h>
 #include <pthread.h>
 #include <semaphore.h>

--- a/lib/libcard.c
+++ b/lib/libcard.c
@@ -54,7 +54,6 @@
 #include <time.h>
 #include <limits.h>
 #include <fcntl.h>
-#define _GNU_SOURCE
 #include <signal.h>
 #include <pthread.h>
 #include <semaphore.h>

--- a/lib/libddcb.c
+++ b/lib/libddcb.c
@@ -35,7 +35,6 @@
 #include <time.h>
 #include <limits.h>
 #include <fcntl.h>
-#define _GNU_SOURCE
 #include <signal.h>
 #include <pthread.h>
 #include <semaphore.h>

--- a/tools/force_cpu.c
+++ b/tools/force_cpu.c
@@ -6,10 +6,8 @@
 #include <signal.h>
 #include <sys/time.h>
 
-#define __USE_GNU
 #include <sched.h>
 
-#define _GNU_SOURCE
 #include <utmpx.h>
 
 #include "force_cpu.h"

--- a/tools/genwqe_cksum.c
+++ b/tools/genwqe_cksum.c
@@ -24,7 +24,6 @@
 #include <sys/time.h>
 #include <asm/byteorder.h>
 
-#define __USE_GNU
 #include <sched.h>
 
 #include "genwqe_tools.h"

--- a/tools/genwqe_echo.c
+++ b/tools/genwqe_echo.c
@@ -32,7 +32,6 @@
 #include <sys/time.h>
 #include <asm/byteorder.h>
 
-#define __USE_GNU
 #include <sched.h>
 
 #include "genwqe_tools.h"

--- a/tools/genwqe_gzip.c
+++ b/tools/genwqe_gzip.c
@@ -45,7 +45,6 @@
 #include <time.h>
 #include <asm/byteorder.h>
 
-#define __USE_GNU
 #include <sched.h>
 
 #include <zlib.h>

--- a/tools/genwqe_memcopy.c
+++ b/tools/genwqe_memcopy.c
@@ -28,7 +28,6 @@
 #include <asm/byteorder.h>
 #include <pthread.h>
 
-#define __USE_GNU
 #include <sched.h>
 
 #include "libddcb.h"

--- a/tools/zlib_mt_perf.c
+++ b/tools/zlib_mt_perf.c
@@ -53,7 +53,6 @@
 #include <sys/time.h>
 #include <asm/byteorder.h>
 
-#define __USE_GNU
 #include <sched.h>
 
 #include <getopt.h>


### PR DESCRIPTION
Fix for issue 111.
It can happen sem_wait to return -1 and EINTR errno is set. We retry in this case.
- Adding _GNU_SOURCE compile flag
- Use GNU macro TEMP_FAILURE_RETRY to retry on EINTR
- Change errno setting from EINTR to EBADF
