### PR TITLE
Fix Makefile when using external libcxl

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -134,11 +134,12 @@ CONFIG_LIBCXL_PATH ?= ../../pslse/libcxl
 CFLAGS += -DCONFIG_BUILD_SIMCODE -I../ext/include
 endif
 
+CFLAGS += -I../include
 # Can be overwritten by makfile option
 ifeq ($(BUNDLE_LIBCXL),1)
 WITH_LIBCXL=1
 CONFIG_LIBCXL_PATH ?= ../ext/libcxl
-CFLAGS += -I../ext/include -I../include
+CFLAGS += -I../ext/include
 endif
 
 # Finally, set any path needed.

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -44,10 +44,10 @@ projs += genwqe_maint genwqe_loadtree
 CAPI_INSTALL=capi_install
 
 # If we are bundling, we need to link statically.  Otherwise, go dynamic.
-ifdef BUNDLE_LIBCXL
+ifeq ($(BUNDLE_LIBCXL),1)
 LDLIBS += $(libcxl_a)
 else
-LDLIBS = -lcxl
+LDLIBS += -lcxl
 endif # !CONFIG_LIBCXL_PATH
 
 endif # WITH_LIBCXL


### PR DESCRIPTION
Currently, when not compiling using BUNDLE_LIBCXL option, it fails to build.

On Ubuntu, where we have the libcxl library, we should use the BUNDLE_LIBCXL=0
when compiling, so, this path should work properly.
