### PR TITLE
Use a variable to where to install the manpages

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -172,3 +172,4 @@ endif
 DESTDIR ?= /usr
 LIB_INSTALL_PATH ?= $(DESTDIR)/lib64/genwqe
 INCLUDE_INSTALL_PATH ?= $(DESTDIR)/include/genwqe
+MAN_INSTALL_PATH ?= $(DESTDIR)/share/man/man1

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -118,13 +118,16 @@ uninstall_gzip_tools:
 	      $(DESTDIR)/bin/genwqe_test_gz
 
 install_manpages: $(manpages)
-	@mkdir -p $(DESTDIR)/share/man/man1
-	cp -uv $(manpages) $(DESTDIR)/share/man/man1
+	@mkdir -p $(MAN_INSTALL_PATH)
+	cp -uv $(manpages) $(MAN_INSTALL_PATH)
 
 install_release_manpages: $(manpages)
-	@mkdir -p $(DESTDIR)/man/man1
+	@mkdir -p $(MAN_INSTALL_PATH)
+
 	cp -uv genwqe_memcopy.1 genwqe_echo.1 genwqe_update.1 \
 		$(DESTDIR)/man/man1
+	cp -uv genwqe_memcopy.1 genwqe_echo.1 genwqe_update.1 \
+		$(MAN_INSTALL_PATH)
 
 uninstall_manpages:
 	@for f in $(manpages) ; do				\


### PR DESCRIPTION
Currently you can set where to install headers/include files and also library,
but not manpages.

This patch just add a variable to define where the man pages will be installed.
