### PR TITLE
Fixing the github URL

### DIFF
--- a/licenses/cla-corporate.txt
+++ b/licenses/cla-corporate.txt
@@ -1,6 +1,6 @@
         International Business machines, Inc.
   Software Grant and Corporate Contributor License Agreement ("Agreement")
-        http://www.github.org/ibm-genwqe/licenses/
+        http://www.github.com/ibm-genwqe/licenses/
 
 
 Thank you for your interest in IBM’s ibm-genwqe project (“Hardware

--- a/licenses/cla-individual.txt
+++ b/licenses/cla-individual.txt
@@ -1,6 +1,6 @@
         International Business Machines, Inc. (IBM)
      Individual Contributor License Agreement ("Agreement")
-        http://www.github.org/ibm-genwqe/licenses/
+        http://www.github.com/ibm-genwqe/licenses/
 
 Thank you for your interest in the ibm-genwqe project ("Hardware
 acceleration of deflate/zlib compression with IBM FPGA accelerators").


### PR DESCRIPTION
Currently licenses show a wrong github URL. This patch just fixes it.