### PR TITLE
Fix compilation on 32-bits arch

### DIFF
--- a/lib/hardware.c
+++ b/lib/hardware.c
@@ -1453,7 +1453,7 @@ int h_inflate(z_streamp strm, int flush)
 
 			rc = __check_stream_end(strm);
 			if (rc == Z_STREAM_END) {
-				hw_trace("    Suppress Z_STREAM_END %ld %ld\n",
+				hw_trace("    Suppress Z_STREAM_END %zd %zd\n",
 					 s->obuf_avail, s->obuf_total);
 				s->rc = Z_STREAM_END;
 				rc = Z_OK;

--- a/lib/software.c
+++ b/lib/software.c
@@ -533,8 +533,8 @@ z_off64_t gztell64(gzFile file)
 	return (* p_gztell64)(file);
 }
 
-static z_off_t (* p_gzseek64)(gzFile file, z_off64_t offset, int whence);
-z_off_t gzseek64(gzFile file, z_off64_t offset, int whence)
+static z_off64_t (* p_gzseek64)(gzFile file, z_off64_t offset, int whence);
+z_off64_t gzseek64(gzFile file, z_off64_t offset, int whence)
 {
 	zlib_stats_inc(&zlib_stats.gzseek64);
 	check_sym(p_gzseek64, -1ll);
@@ -550,7 +550,7 @@ z_off_t gzoffset(gzFile file)
 }
 
 static z_off64_t (* p_gzoffset64)(gzFile file);
-z_off_t gzoffset64(gzFile file)
+z_off64_t gzoffset64(gzFile file)
 {
 	zlib_stats_inc(&zlib_stats.gzoffset64);
 	check_sym(p_gzoffset64, -1ll);


### PR DESCRIPTION
This is a fix for the issues we are facing on Debian and Ubuntu, where genwqe fails to build on 32-bits architectures.