### PR TITLE
Verify deflate set dict

### DIFF
--- a/lib/ddcb_capi.c
+++ b/lib/ddcb_capi.c
@@ -432,8 +432,9 @@ static int __afu_open(struct dev_ctx *ctx)
 	rc = cxl_get_cr_device(ctx->afu_h, 0, &ctx->cr_device);
 	if (rc == 0) {
 		if (ctx->cr_device != CGZIP_CR_DEVICE) {
-			VERBOSE0(" [%s] ERR: device_id: %ld/%d\n",
-				 __func__, (unsigned long)ctx->cr_device,
+			VERBOSE1(" [%s] WARNING: device_id: %ld/%d "
+				 "skipping, no CGZIP card\n", __func__,
+				 (unsigned long)ctx->cr_device,
 				 CGZIP_CR_VENDOR);
 			rc = DDCB_ERR_CARD;
 			goto err_afu_free;

--- a/lib/deflate.c
+++ b/lib/deflate.c
@@ -292,6 +292,9 @@ int zedc_deflateSetDictionary(zedc_streamp strm,
 	if (dictLength > ZEDC_DICT_LEN)
 		return ZEDC_STREAM_ERROR;
 
+	if (dictionary == NULL)
+		return ZEDC_STREAM_ERROR;
+
 	memcpy(&strm->wsp->dict[0], dictionary, dictLength);
 	strm->dict_len = dictLength;
 	strm->dict_adler32 = __adler32(1, dictionary, dictLength);

--- a/lib/wrapper.c
+++ b/lib/wrapper.c
@@ -626,6 +626,9 @@ int deflateSetDictionary(z_streamp strm,
 	strm->state = w->priv_data;
 	rc = w->impl ? h_deflateSetDictionary(strm, dictionary, dictLength) :
 		       z_deflateSetDictionary(strm, dictionary, dictLength);
+	
+	pr_trace("[%p]    calculated adler32=%08x\n", strm,
+		 (unsigned int)strm->adler);
 	strm->state = (void *)w;
 
 	return rc;

--- a/misc/zpipe_rnd.c
+++ b/misc/zpipe_rnd.c
@@ -470,7 +470,6 @@ int main(int argc, char **argv)
 
 	/* do compression if no arguments */
 	if (compress == 1) {
-		fprintf(stderr, "level: %d strategy: %d\n", level, strategy);
 		ret = def(stdin, stdout, level, strategy,
 			  windowBits, dictionary, dictLength);
 		if (ret != Z_OK)


### PR DESCRIPTION
The setDictionary needs to return the ADLER32 value of the passed dictionary. This was not the case got fixed. Once the value was returned the start value of 1 is taken again for the data itself.