### PR TITLE
GenWQE: Fix for deflate bound/execute EOB software circumvention after hardware inflate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
-dist: trusty
+dist: xenial
+# dist: trusty
 language: c
 compiler: gcc
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: xenial
 language: c
 compiler: gcc
 before_install:
+  - sudo apt-get remove oracle-java9-installer
   - sudo dpkg --add-architecture i386
   - sudo apt-get -qq update
   - sudo apt-cache search zlib

--- a/config.mk
+++ b/config.mk
@@ -62,7 +62,7 @@ ifeq (${HAS_GIT},y)
 VERSION ?= $(shell git describe --abbrev=4 --always --tags | sed -e 's/v//g')
 RPMVERSION ?= $(shell git describe --abbrev=0 --tags | cut -c 2-7)
 else
-VERSION=4.0.18
+VERSION=4.0.19
 RPMVERSION=$(VERSION)
 endif
 MAJOR_VERS=$(shell echo $(VERSION) | cut -d'.' -f1)

--- a/include/libzHW.h
+++ b/include/libzHW.h
@@ -480,7 +480,10 @@ int zedc_inflateGetHeader(zedc_streamp strm, gzedc_headerp head);
 int zedc_inflateSaveBuffers(zedc_streamp strm, const char *prefix);
 void zedc_lib_debug(int onoff);	/* debug outputs on/off */
 void zedc_set_logfile(FILE *logfile);
+
 int zedc_inflate_pending_output(struct zedc_stream_s *strm);
+int zedc_read_pending_output(struct zedc_stream_s *strm,
+			uint8_t *buf, unsigned int len);
 
 /**
  * The application can compare zedc_Version and ZEDC_VERSION for

--- a/lib/hardware.c
+++ b/lib/hardware.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, International Business Machines
+ * Copyright 2015, 2017 International Business Machines
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1606,7 +1606,7 @@ int h_inflateEnd(z_streamp strm)
 	ibuf_bytes = s->ibuf - s->ibuf_base;  /* accumulated input */
 	obuf_bytes = s->obuf - s->obuf_next;  /* bytes in obuf */
 	if (ibuf_bytes || obuf_bytes)
-		pr_err("[%p] In/Out buffer not empty! ibuf_bytes=%d "
+		hw_trace("[%p] In/Out buffer not empty! ibuf_bytes=%d "
 		       "obuf_bytes=%d\n", strm, ibuf_bytes, obuf_bytes);
 
 	rc = zedc_inflateEnd(h);

--- a/lib/hardware.c
+++ b/lib/hardware.c
@@ -1461,6 +1461,13 @@ int h_inflate(z_streamp strm, int flush)
 		    (strm->avail_out == 0))
 			return Z_OK;		/* need new output buffer */
 
+#if 0
+/*
+ *  FIXME We have put this now behind the hardware decompression, where
+ * it should have been already from the beginning. Wonder if that
+ * is passing all the testcases. If it does, we can hopefully remove
+ * this.
+ */
 		/*
 		 * Need more output space, just useful if Z_STREAM_END
 		 * not seen before.
@@ -1485,6 +1492,7 @@ int h_inflate(z_streamp strm, int flush)
 #endif
 			return rc;
 		}
+#endif
 
 		/*
 		 * Original idea: Do not send 0 data to HW

--- a/lib/inflate.c
+++ b/lib/inflate.c
@@ -769,6 +769,37 @@ int zedc_inflate_pending_output(struct zedc_stream_s *strm)
 }
 
 /**
+ * @brief	Enable wrapper code to access internal buffer.
+ * 		If data is left from previous task due to insufficent
+ *		output buffer space, this data must first be stored
+ *		to the new output buffer.
+ * @param strm	decompression job context
+ */
+int zedc_read_pending_output(struct zedc_stream_s *strm,
+			uint8_t *buf, unsigned int len)
+{
+	uint8_t *pdict;
+	unsigned int _len = 0;
+
+	if (strm->obytes_in_dict == 0)
+		return ZEDC_OK;
+	if (strm->dict_len < strm->obytes_in_dict)
+		return ZEDC_ERR_DICT_OVERRUN;
+
+	/* obytes at end of dict */
+	pdict = strm->wsp->dict[strm->wsp_page] +
+		strm->out_dict_offs + strm->dict_len - strm->obytes_in_dict;
+
+	while (len && strm->obytes_in_dict) {
+		*buf++ = *pdict++;
+		strm->obytes_in_dict--;
+		len--;
+		_len++;
+	}
+	return _len;
+}
+
+/**
  * @brief	If data is left from previous task due to insufficent
  *		output buffer space, this data must first be stored
  *		to the new output buffer.

--- a/lib/wrapper.c
+++ b/lib/wrapper.c
@@ -811,8 +811,10 @@ uLong deflateBound(z_streamp strm, uLong sourceLen)
 	int rc;
 	struct _internal_state *w;
 
-	if (strm == NULL)
-		return Z_STREAM_ERROR;
+	if (strm == NULL) {
+		return MAX(h_deflateBound(NULL, sourceLen),
+			   z_deflateBound(NULL, sourceLen));
+	}
 
 	w = (struct _internal_state *)strm->state;
 	if (w == NULL)

--- a/lib/wrapper.h
+++ b/lib/wrapper.h
@@ -43,6 +43,12 @@
 			_a < _b ? _a : _b; })
 #endif
 
+#ifndef MAX
+#  define MAX(a,b)	({ __typeof__ (a) _a = (a); \
+			   __typeof__ (b) _b = (b); \
+			_a > _b ? _a : _b; })
+#endif
+
 #ifndef __unused
 #  define __unused __attribute__((unused))
 #endif

--- a/misc/basic_hardware_tests.sh
+++ b/misc/basic_hardware_tests.sh
@@ -84,6 +84,12 @@ for accel in GENWQE CAPI ; do
 	for card in `./tools/genwqe_find_card -A${accel}`; do
 		echo "TESTING ${accel} CARD ${card}"
 
+		zlib_git.sh  -A${accel} -C${card}
+		if [ $? -ne 0 ]; then
+			echo "FAILED ${accel} CARD ${card}"
+			exit 1
+		fi
+
 		zlib_test.sh  -A${accel} -C${card}
 		if [ $? -ne 0 ]; then
 			echo "FAILED ${accel} CARD ${card}"

--- a/misc/basic_software_tests.sh
+++ b/misc/basic_software_tests.sh
@@ -22,7 +22,7 @@
 # test data is not available. Use for automated regression testing.
 #
 
-export PATH=`pwd`/tools:$PATH
+export PATH=`pwd`/tools:`pwd`/misc:$PATH
 export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
 
 # Checks
@@ -38,6 +38,12 @@ card=0
 
 echo "Testing fallback to software if there is no card available"
 echo "TESTING ${accel} CARD ${card}"
+
+zlib_git.sh  -A${accel} -C${card}
+if [ $? -ne 0 ]; then
+	echo "FAILED ${accel} CARD ${card}"
+	exit 1
+fi
 
 genwqe_mt_perf -A${accel} -C${card} -M4
 if [ $? -ne 0 ]; then

--- a/misc/zlib_git.sh
+++ b/misc/zlib_git.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+#
+# Copyright 2017 International Business Machines
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Some tests to ensure proper function of the hardware accelerated zlib.
+#
+# Setup tools path, such that we do not need to prefix the binaries and
+# test-script. This should also help to reduce change effort when we
+# move our test binaries from one to another source code repository.
+#
+
+card=0
+
+export ZLIB_ACCELERATOR=GENWQE
+export ZLIB_LOGFILE=zlib.log
+export ZLIB_TRACE=0x8
+
+export PATH=`pwd`/tools:`pwd`/misc:$PATH
+export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
+
+function usage() {
+    echo "Usage:"
+    echo "  zlib_git.sh"
+    echo "    [-A] <accelerator> use either GENWQE for the PCIe and CAPI for"
+    echo "         CAPI based solution available only on System p"
+    echo "    [-C <card>]        card to be used for the test"
+    echo "    [-t <trace_level>]"
+}
+
+while getopts "A:C:t:h" opt; do
+    case $opt in
+	A)
+	export ZLIB_ACCELERATOR=$OPTARG;
+	;;
+	C)
+	card=$OPTARG;
+	;;
+	t)
+	export ZLIB_TRACE=$OPTARG;
+	;;
+	h)
+	usage;
+	exit 0;
+	;;
+	\?)
+	echo "Invalid option: -$OPTARG" >&2
+	;;
+    esac
+done
+
+ulimit -c unlimited
+
+if [ ! -f `pwd`/lib/libzADC.so ]; then
+	echo "err: Please build the code prior executing this."
+	exit -1
+fi
+
+echo -n "Trying out git log ... "
+LD_PRELOAD=`pwd`/lib/libzADC.so git log > git.log
+if [ $? -ne 0 ]; then
+	echo "err: git log failed!"
+	exit 1
+fi
+echo "OK"
+
+# FIXME Add more stuff here to ensure that it fully works ...
+
+exit 0

--- a/misc/zlib_test.sh
+++ b/misc/zlib_test.sh
@@ -189,9 +189,13 @@ function test_compress_decompress_fixed() {
 
 function build_code ()
 {
-    echo "--------------------------------------------------------------------"
-    echo "Build code ..."
-    make || exit 1
+	# Do not build the code, there might be some options e.g. not
+	# using libcxl, which must be set such that the build can
+	# Succeed on some special test-systems we have.
+
+    #echo "--------------------------------------------------------------------"
+    #echo "Build code ..."
+    #make || exit 1
 
     echo "--------------------------------------------------------------------"
     if [ -f test_data.bin ]; then

--- a/misc/zpipe_append.c
+++ b/misc/zpipe_append.c
@@ -3,7 +3,7 @@
    Version 1.4	11 December 2005  Mark Adler */
 
 /*
- * Copyright 2016, International Business Machines
+ * Copyright 2016, 2017 International Business Machines
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -375,13 +375,14 @@ static void usage(char *prog)
 
 	fprintf(stderr, "%s usage: %s [-h] [-v]\n"
 		"    [-F, --format <ZLIB|DEFLATE|GZIP>]\n"
-		"    [-e, --excact-input]  input matches size of data\n"
+		"    [-e, --excact-input] input matches size of data\n"
 		"    [-E, --excact-output] output matches size of data\n"
 		"    [-f, --fush <Z_NO_FLUSH|Z_PARTIAL_FLUSH|Z_FULL_FLUSH>]\n"
 		"    [-i, --i_bufsize <i_bufsize>]\n"
 		"    [-o, --o_bufsize <o_bufsize>]\n"
 		"    [-p, --pattern <pattern>] pattern to generate test-data\n"
-		"    [-s, --size <data-size>]\n",
+		"    [-s, --size <data-size>]\n"
+		"    [-k, --keep] do not delete resulting files\n",
 		b, b);
 }
 
@@ -400,6 +401,7 @@ int main(int argc, char **argv)
 	int exact_input = 0, exact_output = 0;
 	size_t size = 256 * 1024;
 	int expect_z_stream_end = 0;
+	int keep = 0;
 
 	_pattern = getpid();
 
@@ -419,12 +421,13 @@ int main(int argc, char **argv)
 			{ "o_bufsize",	 required_argument, NULL, 'o' },
 			{ "size",	 required_argument, NULL, 's' },
 			{ "pattern",	 required_argument, NULL, 'p' },
+			{ "keep",	 no_argument,       NULL, 'k' },
 			{ "verbose",	 no_argument,	    NULL, 'v' },
 			{ "help",	 no_argument,	    NULL, 'h' },
 			{ 0,		 no_argument,	    NULL, 0   },
 		};
 
-		ch = getopt_long(argc, argv, "F:f:Eei:o:s:p:vh?",
+		ch = getopt_long(argc, argv, "kF:f:Eei:o:s:p:vh?",
 				 long_options, &option_index);
 		if (ch == -1)    /* all params processed ? */
 			break;
@@ -449,6 +452,9 @@ int main(int argc, char **argv)
 			break;
 		case 'E':
 			exact_output = 1;
+			break;
+		case 'k':
+			keep = 1;
 			break;
 		case 'v':
 			verbose++;
@@ -589,9 +595,11 @@ int main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	unlink(i_fname);
-	unlink(n_fname);
-	unlink(o_fname);
+	if (!keep) {
+		unlink(i_fname);
+		unlink(n_fname);
+		unlink(o_fname);
+	}
 
 	exit(EXIT_SUCCESS);
 }

--- a/spec/genwqe.spec
+++ b/spec/genwqe.spec
@@ -22,7 +22,7 @@
 
 Summary: GenWQE userspace tools
 Name:    genwqe-tools
-Version: 4.0.18
+Version: 4.0.19
 Release: 1%{?dist}
 License: Apache-2.0
 Group: Development/Tools


### PR DESCRIPTION
Contains multiple changes:
* Fix for deflateBound()
* Fix for Z_STREAM_END circumvention, which caused that we needed to call inflate() twice instead of required once to get the right Z_STREAM_END return code
* Fix for potential security problem by using ZLIB_PATH to load arbitrary libz.so as software fallback

