### PR TITLE
Add version printout

### DIFF
--- a/tools/genwqe_gzip.c
+++ b/tools/genwqe_gzip.c
@@ -321,13 +321,15 @@ static void print_args(FILE *fp, int argc, char **argv)
 	fprintf(fp, "Called with:\n");
 	for (i = 0; i < argc; i++)
 		fprintf(fp, "  ARGV[%d]: \"%s\"\n", i, argv[i]);
+	fprintf(fp, "\n");
 }
 
 static void print_version(FILE *fp)
 {
-	fprintf(fp, "Code: zlibVersion()=%s Header: ZLIB_VERSION=%s %s\n",
+	fprintf(fp, "Code: zlibVersion()=%s Header: ZLIB_VERSION=%s %s\n\n",
 		zlibVersion(), ZLIB_VERSION,
-		strcmp(zlibVersion(), ZLIB_VERSION) == 0 ? "consistent" : "inconsistent");
+		strcmp(zlibVersion(), ZLIB_VERSION) == 0 ?
+		"consistent" : "inconsistent");
 }
 
 static void usage(FILE *fp, char *prog, int argc, char *argv[])

--- a/tools/genwqe_gzip.c
+++ b/tools/genwqe_gzip.c
@@ -310,7 +310,7 @@ static inline uint64_t str_to_num(char *str)
 
 static void userinfo(FILE *fp, char *prog, const char *version)
 {
-	fprintf(fp, "%s %s\n(c) Copyright IBM Corp. 2015\n",
+	fprintf(fp, "%s %s\n(c) Copyright IBM Corp. 2015, 2017\n",
 		basename(prog), version);
 }
 
@@ -321,6 +321,13 @@ static void print_args(FILE *fp, int argc, char **argv)
 	fprintf(fp, "Called with:\n");
 	for (i = 0; i < argc; i++)
 		fprintf(fp, "  ARGV[%d]: \"%s\"\n", i, argv[i]);
+}
+
+static void print_version(FILE *fp)
+{
+	fprintf(fp, "Code: zlibVersion()=%s Header: ZLIB_VERSION=%s %s\n",
+		zlibVersion(), ZLIB_VERSION,
+		strcmp(zlibVersion(), ZLIB_VERSION) == 0 ? "consistent" : "inconsistent");
 }
 
 static void usage(FILE *fp, char *prog, int argc, char *argv[])
@@ -363,6 +370,7 @@ static void usage(FILE *fp, char *prog, int argc, char *argv[])
 		"Report bugs via https://github.com/ibm-genwqe/genwqe-user.\n"
 		"\n", prog, CHUNK_i/1024, CHUNK_o/1024);
 
+	print_version(fp);
 	print_args(fp, argc, argv);
 }
 


### PR DESCRIPTION
We need to prepare compiling the code against a different zlib version. The version printout is meant as sanity check to see if the library used matches the header file taken during the build step.