### PR TITLE
do not define gettid() if glibc >=2.30 is used

### DIFF
--- a/lib/card_defs.h
+++ b/lib/card_defs.h
@@ -32,10 +32,22 @@
 #include <unistd.h>
 #include <sys/syscall.h>   /* For SYS_xxx definitions */
 
+#ifdef __BIONIC__
+  #define OVERRIDE_GETTID 0
+#elif !defined(__GLIBC_PREREQ)
+  #define OVERRIDE_GETTID 1
+#elif !__GLIBC_PREREQ(2,30)
+  #define OVERRIDE_GETTID 1
+#else
+  #define OVERRIDE_GETTID 0
+#endif
+
+#if OVERRIDE_GETTID
 static inline pid_t gettid(void)
 {
 	return (pid_t)syscall(SYS_gettid);
 }
+#endif
 
 #define pr_err(fmt, ...)						\
 	fprintf(stderr, "%08x.%08x %s:%u: Error: " fmt,			\

--- a/lib/ddcb_capi.c
+++ b/lib/ddcb_capi.c
@@ -61,10 +61,22 @@ extern FILE *libddcb_fd_out;
 
 #include <sys/syscall.h>   /* For SYS_xxx definitions */
 
+#ifdef __BIONIC__
+  #define OVERRIDE_GETTID 0
+#elif !defined(__GLIBC_PREREQ)
+  #define OVERRIDE_GETTID 1
+#elif !__GLIBC_PREREQ(2,30)
+  #define OVERRIDE_GETTID 1
+#else
+  #define OVERRIDE_GETTID 0
+#endif
+
+#if OVERRIDE_GETTID
 static inline pid_t gettid(void)
 {
 	return (pid_t)syscall(SYS_gettid);
 }
+#endif
 
 #define VERBOSE0(fmt, ...) do {						\
 		if (libddcb_fd_out)					\

--- a/lib/hw_defs.h
+++ b/lib/hw_defs.h
@@ -33,10 +33,22 @@
 #  define ABS(a)	 (((a) < 0) ? -(a) : (a))
 #endif
 
+#ifdef __BIONIC__
+  #define OVERRIDE_GETTID 0
+#elif !defined(__GLIBC_PREREQ)
+  #define OVERRIDE_GETTID 1
+#elif !__GLIBC_PREREQ(2,30)
+  #define OVERRIDE_GETTID 1
+#else
+  #define OVERRIDE_GETTID 0
+#endif
+
+#if OVERRIDE_GETTID
 static inline pid_t gettid(void)
 {
 	return (pid_t)syscall(SYS_gettid);
 }
+#endif
 
 extern int zedc_dbg;
 extern FILE *zedc_log;

--- a/misc/zpipe_append.c
+++ b/misc/zpipe_append.c
@@ -61,10 +61,22 @@ static unsigned int CHUNK_i = 16 * 1024; /* 16384; */
 static unsigned int CHUNK_o = 16 * 1024; /* 16384; */
 static int _pattern = 0;
 
+#ifdef __BIONIC__
+  #define OVERRIDE_GETTID 0
+#elif !defined(__GLIBC_PREREQ)
+  #define OVERRIDE_GETTID 1
+#elif !__GLIBC_PREREQ(2,30)
+  #define OVERRIDE_GETTID 1
+#else
+  #define OVERRIDE_GETTID 0
+#endif
+
+#if OVERRIDE_GETTID
 static inline pid_t gettid(void)
 {
 	return (pid_t)syscall(SYS_gettid);
 }
+#endif
 
 static int figure_out_window_bits(const char *format)
 {

--- a/misc/zpipe_mt.c
+++ b/misc/zpipe_mt.c
@@ -126,10 +126,22 @@ static int pin_to_cpu(int run_cpu)
 	return run_cpu;
 }
 
+#ifdef __BIONIC__
+  #define OVERRIDE_GETTID 0
+#elif !defined(__GLIBC_PREREQ)
+  #define OVERRIDE_GETTID 1
+#elif !__GLIBC_PREREQ(2,30)
+  #define OVERRIDE_GETTID 1
+#else
+  #define OVERRIDE_GETTID 0
+#endif
+
+#if OVERRIDE_GETTID
 static pid_t gettid(void)
 {
 	return (pid_t)syscall(SYS_gettid);
 }
+#endif
 
 static inline unsigned long get_nsec(void)
 {

--- a/tools/zlib_mt_perf.c
+++ b/tools/zlib_mt_perf.c
@@ -162,10 +162,22 @@ static int pin_to_cpu(int run_cpu)
 	return run_cpu;
 }
 
+#ifdef __BIONIC__
+  #define OVERRIDE_GETTID 0
+#elif !defined(__GLIBC_PREREQ)
+  #define OVERRIDE_GETTID 1
+#elif !__GLIBC_PREREQ(2,30)
+  #define OVERRIDE_GETTID 1
+#else
+  #define OVERRIDE_GETTID 0
+#endif
+
+#if OVERRIDE_GETTID
 static pid_t gettid(void)
 {
 	return (pid_t)syscall(SYS_gettid);
 }
+#endif
 
 static inline unsigned long get_nsec(void)
 {


### PR DESCRIPTION
Since version 2.30 glibc implements gettid() system call wrapper, genwqe-use breaks with the compiler error: "error: static declaration of ‘gettid’ follows non-static declaration"

For more info please have a look at https://bugzilla.redhat.com/show_bug.cgi?id=1735243  (genwqe-tools: FTBFS in Fedora rawhide/f31)

The proposed patch resolves the reported issue.